### PR TITLE
Update poll routes & poll views & poll and response models

### DIFF
--- a/app/controllers/polls.rb
+++ b/app/controllers/polls.rb
@@ -1,33 +1,37 @@
 get '/polls' do
-  @surveys = Survey.all
+  @polls = Poll.all
   erb :'polls/index'
 end
 
 get '/polls/:id' do
-  # Note: This route assumes the user is logged in
-  # Need to implement error handling for this route to function fully
-  @poll = Poll.new(user_id: current_user.id, survey_id: params[:id])
-  if @poll.save
-    @survey = Survey.find(params[:id])
-    erb :'polls/show'
-  else
-    @errors = @poll.errors.full_messages
-    erb :'polls/index'
-  end
-end
-
-post '/polls' do
-  poll = params[:response][:poll_id]
-  choices = params[:response][:choices]
-  @surveys = Survey.all
-  choices.values.each do |choice|
-    Response.create(poll_id: poll, choice_id: choice)
-  end
-  erb :'polls/complete'
-
+  @poll = Poll.find(params[:id])
+  erb :'polls/show'
 end
 
 get '/surveys/:survey_id/polls' do
   @survey = Survey.find_by(id: params[:survey_id])
   erb :'surveys/polls'
+end
+
+# Need to implement error handling on surveys/index route 
+# for this route to function fully
+get '/surveys/:survey_id/polls/new' do
+  # Note: Need to change this to 'user_id: current_user' when 
+  # user authentication is added
+  @poll = Poll.new(user_id: 1, survey_id: params[:survey_id])
+  if @poll.save
+    erb :'polls/new'
+  else
+    @errors = @poll.errors.full_messages
+    erb :'surveys/index'
+  end
+end
+
+post '/surveys/:survey_id/polls' do
+  @poll = Poll.find(params[:response][:poll_id])
+  choices = params[:response][:choices]
+  choices.values.each do |choice|
+    Response.create(poll_id: @poll.id, choice_id: choice)
+  end
+  erb :'polls/complete'
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -19,8 +19,4 @@ class Poll < ActiveRecord::Base
   def survey_name
     self.survey.name
   end
-
-  def questions
-    self.survey.questions
-  end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -16,4 +16,11 @@ class Poll < ActiveRecord::Base
     self.user.username
   end
 
+  def survey_name
+    self.survey.name
+  end
+
+  def questions
+    self.survey.questions
+  end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -1,19 +1,13 @@
 class Response < ActiveRecord::Base
   belongs_to :poll
   belongs_to :choice
+  has_one :question, :through => :choice
+  has_many :choices, :through => :question
 
   validates :poll_id, presence: true
   validates :choice_id, presence: true
 
-  def question
-    self.choice.question.text
-  end
-
   def text
     self.choice.text
-  end
-
-  def question_choices
-    self.choice.question.choices
   end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -4,4 +4,16 @@ class Response < ActiveRecord::Base
 
   validates :poll_id, presence: true
   validates :choice_id, presence: true
+
+  def question
+    self.choice.question.text
+  end
+
+  def text
+    self.choice.text
+  end
+
+  def question_choices
+    self.choice.question.choices
+  end
 end

--- a/app/views/_list_of_polls.erb
+++ b/app/views/_list_of_polls.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% polls.each do |poll| %>
+    <li><a href="/polls/<%= poll.id %>">"<%= poll.survey_name %>" taken <%= poll.nice_date %> by <%= poll.taker %></a></li>
+  <% end %>
+</ul>

--- a/app/views/_list_of_surveys.erb
+++ b/app/views/_list_of_surveys.erb
@@ -1,5 +1,0 @@
-<ul>
-  <% surveys.each do |survey| %>
-    <li><a href="/polls/<%= survey.id %>"><%= survey.name %></a></li>
-  <% end %>
-</ul>

--- a/app/views/polls/complete.erb
+++ b/app/views/polls/complete.erb
@@ -1,5 +1,4 @@
 <div id="container">
   <h1>Thank you for completing our poll!</h1>
-  <h3>Check out the rest of our polls:</h3>
-  <%= erb :_list_of_surveys, locals: {surveys: @surveys} %>
+  <h3><a href="/">Check out the rest of our polls!</a></h3>
 </div>

--- a/app/views/polls/index.erb
+++ b/app/views/polls/index.erb
@@ -1,5 +1,4 @@
 <div id="container">
-  <h1>Take one of our polls!</h1>
-  <h3>Click on any of the below polls to submit your responses</h3>
-  <%= erb :_list_of_surveys, locals: {surveys: @surveys} %>
+  <h1>Here are all of the polls that have been recorded:</h1>
+  <%= erb :_list_of_polls, locals: {polls: @polls} %>
 </div>

--- a/app/views/polls/new.erb
+++ b/app/views/polls/new.erb
@@ -1,0 +1,18 @@
+<div id="container">
+  <h4>You are taking our poll:</h4>
+  <h1><%= @poll.survey.name %></h1>
+  <form method="post" action="/surveys/<%= @poll.survey.id %>/polls">
+    <% @poll.questions.each do |question| %>
+      <fieldset>
+        <legend><%= question.text %></legend>
+        <p>
+          <% question.choices.each do |choice| %>
+            <input type="radio" name="response[choices][<%= question.id %>]" id="<%= choice.text %>" value="<%= choice.id %>" required> <%= choice.text %><br>
+          <% end %>
+        </p>
+      </fieldset>
+    <% end %>
+    <input id="response_poll_id_input" name="response[poll_id]" type="hidden" value="<%= @poll.id %>">
+    <p><input type="submit" value="Submit Poll Responses" class="button"></p>
+  </form>
+</div>

--- a/app/views/polls/new.erb
+++ b/app/views/polls/new.erb
@@ -1,6 +1,6 @@
 <div id="container">
   <h4>You are taking our poll:</h4>
-  <h1><%= @poll.survey.name %></h1>
+  <h1><%= @poll.survey_name %></h1>
   <form method="post" action="/surveys/<%= @poll.survey.id %>/polls">
     <% @poll.questions.each do |question| %>
       <fieldset>

--- a/app/views/polls/show.erb
+++ b/app/views/polls/show.erb
@@ -1,18 +1,16 @@
-<div id="container">
-  <h4>You are taking our poll:</h4>
-  <h1><%= @survey.name %></h1>
-  <form method="post" action="/polls">
-    <% @survey.questions.each do |question| %>
-      <fieldset>
-        <legend><%= question.text %></legend>
-        <p>
-          <% question.choices.each do |choice| %>
-            <input type="radio" name="response[choices][<%= question.id %>]" id="<%= choice.text %>" value="<%= choice.id %>"> <%= choice.text %><br>
+<div class='container'>
+  <h3>Survey: <%= @poll.survey_name %></h3>
+  <h6><%= "(taken by #{@poll.taker} on #{@poll.nice_date})" %></h6>
+  <% @poll.responses.each do |response| %>
+    <div>
+      <p>Question: <em><%= response.question %></em></p>
+      <p> Response: <strong><%= response.text %></strong></p>
+      <p>From these choices:</p>
+        <ul>
+          <% response.question_choices.each do |choice| %>
+            <li><%= choice.text %></li>
           <% end %>
-        </p>
-      </fieldset>
-    <% end %>
-    <input id="response_poll_id_input" name="response[poll_id]" type="hidden" value="<%= @poll.id %>">
-    <p><input type="submit" value="Submit Poll Responses" class="button"></p>
-  </form>
+        </ul>
+    </div>
+  <% end %>
 </div>

--- a/app/views/polls/show.erb
+++ b/app/views/polls/show.erb
@@ -3,11 +3,11 @@
   <h6><%= "(taken by #{@poll.taker} on #{@poll.nice_date})" %></h6>
   <% @poll.responses.each do |response| %>
     <div>
-      <p>Question: <em><%= response.question %></em></p>
+      <p>Question: <em><%= response.question.text %></em></p>
       <p> Response: <strong><%= response.text %></strong></p>
       <p>From these choices:</p>
         <ul>
-          <% response.question_choices.each do |choice| %>
+          <% response.choices.each do |choice| %>
             <li><%= choice.text %></li>
           <% end %>
         </ul>


### PR DESCRIPTION
Extensive update of all poll routes and all poll views to accomplish the following:

-All logic now starts from polls table
-Any chained logic has been moved to models
-Routes now follow RESTful conventions, including nested routes

Note: We need to create a way to get to the polls/new view, so a taker can actually take a poll. Perhaps we start the user on the surveys/index view, and that view links to the polls/new view for taking a new poll?

(Also note: the name of this branch, polls/new-route, is a misnomer. I worked on a lot more than the polls/new route. Not confident enough yet to rename a branch, don't want to lose any changes.)

@dcr8898 @StevenXL 
