### PR TITLE
Move /polls/:id route to bottom of controller.

### DIFF
--- a/app/controllers/polls.rb
+++ b/app/controllers/polls.rb
@@ -8,17 +8,12 @@ get'/polls/:poll_id/responses' do |id|
   erb :'polls/show'
 end
 
-get '/polls/:id' do
-  @poll = Poll.find(params[:id])
-  erb :'polls/show'
-end
-
 get '/surveys/:survey_id/polls' do
   @survey = Survey.find_by(id: params[:survey_id])
   erb :'surveys/polls'
 end
 
-# Need to implement error handling on surveys/index route 
+# Need to implement error handling on surveys/index route
 # for this route to function fully
 get '/surveys/:survey_id/polls/new' do
   @poll = Poll.new(user_id: current_user.id, survey_id: params[:survey_id])
@@ -37,4 +32,9 @@ post '/surveys/:survey_id/polls' do
     Response.create(poll_id: poll.id, choice_id: choice)
   end
   redirect "/polls/#{poll.id}/responses"
+end
+
+get '/polls/:id' do
+  @poll = Poll.find(params[:id])
+  erb :'polls/show'
 end


### PR DESCRIPTION
Minor bug fix to avoid having the :id wildcard slurp up other routes unintentionally.

This may be a minor (or even imaginary) issue if no other route are actually affected.  I tried to enter /polls/new into the browser by hand and ran into it, so I thought I would fix it.
